### PR TITLE
Adjust schema for SQLite

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,8 @@ model Skill {
   unlocks       SkillRelation[] @relation("UnlocksFromSkill")
 
   userSkills    UserSkill[]
+  roleSkills    RoleSkill[]
+  courseSkills  CourseSkill[]
 }
 
 model SkillRelation {
@@ -39,17 +41,19 @@ model SkillRelation {
 }
 
 model Role {
-  id               String   @id
-  title            String
-  description      String
-  requiredSkillIds String[]
+  id          String   @id
+  title       String
+  description String
+
+  roleSkills RoleSkill[]
 }
 
 model Course {
   id          String   @id
   title       String
   description String
-  skillIds    String[]
+
+  courseSkills CourseSkill[]
 }
 
 model UserSkill {
@@ -59,4 +63,24 @@ model UserSkill {
   skillId String
 
   @@id([userId, skillId])
+}
+
+model RoleSkill {
+  roleId  String
+  skillId String
+
+  role  Role  @relation(fields: [roleId], references: [id])
+  skill Skill @relation(fields: [skillId], references: [id])
+
+  @@id([roleId, skillId])
+}
+
+model CourseSkill {
+  courseId String
+  skillId  String
+
+  course Course @relation(fields: [courseId], references: [id])
+  skill  Skill  @relation(fields: [skillId], references: [id])
+
+  @@id([courseId, skillId])
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -8,14 +8,29 @@ async function main() {
   await prisma.course.deleteMany();
 
   // Skills
-  await prisma.skill.createMany({
-    data: [
-      { id: 'stat-dist', title: 'Statistical Distributions', description: 'Understand probability distributions', image: '', prereqIds: [] },
-      { id: 't-tests', title: 't-Tests', description: 'Perform hypothesis testing', image: '', prereqIds: ['stat-dist'] },
-      { id: 'conf-int', title: 'Confidence Intervals', description: 'Estimate ranges', image: '', prereqIds: ['stat-dist'] },
-      { id: 'regression', title: 'Regression', description: 'Fit linear models', image: '', prereqIds: ['t-tests','conf-int'] },
-    ],
-  });
+  const skills = [
+    { id: 'stat-dist', title: 'Statistical Distributions', description: 'Understand probability distributions', image: '', prereqIds: [] },
+    { id: 't-tests', title: 't-Tests', description: 'Perform hypothesis testing', image: '', prereqIds: ['stat-dist'] },
+    { id: 'conf-int', title: 'Confidence Intervals', description: 'Estimate ranges', image: '', prereqIds: ['stat-dist'] },
+    { id: 'regression', title: 'Regression', description: 'Fit linear models', image: '', prereqIds: ['t-tests','conf-int'] },
+  ];
+
+  for (const s of skills) {
+    await prisma.skill.create({
+      data: {
+        id: s.id,
+        title: s.title,
+        description: s.description,
+        image: s.image,
+      },
+    });
+  }
+
+  for (const s of skills) {
+    for (const prereq of s.prereqIds) {
+      await prisma.skillRelation.create({ data: { fromId: prereq, toId: s.id } });
+    }
+  }
 
   // Role
   await prisma.role.create({
@@ -23,7 +38,9 @@ async function main() {
       id: 'statistician',
       title: 'Statistician',
       description: 'Expert in statistical analysis',
-      requiredSkillIds: ['stat-dist', 't-tests', 'conf-int'],
+      roleSkills: {
+        create: ['stat-dist', 't-tests', 'conf-int'].map((skillId) => ({ skill: { connect: { id: skillId } } })),
+      },
     },
   });
 
@@ -33,7 +50,9 @@ async function main() {
       id: 'stat-learning',
       title: 'Statistical Learning',
       description: 'Covers hypothesis testing and regression',
-      skillIds: ['stat-dist', 't-tests', 'conf-int', 'regression'],
+      courseSkills: {
+        create: ['stat-dist', 't-tests', 'conf-int', 'regression'].map((skillId) => ({ skill: { connect: { id: skillId } } })),
+      },
     },
   });
 }


### PR DESCRIPTION
## Summary
- redesign schema relations to avoid String[]
- adapt seed data creation to use join tables
- update API tree endpoint to emit arrays from relations

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module '@prisma/client' etc.)*


------
https://chatgpt.com/codex/tasks/task_b_68594543d54883219828559fbd383206