### PR TITLE
Fix build with proper alias for beautiful-skill-tree

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,11 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      'beautiful-skill-tree': 'beautiful-skill-tree/dist/beautiful-skill-tree.esm.js'
+    }
+  },
   server: {
     port: 3000
   }


### PR DESCRIPTION
## Summary
- alias `beautiful-skill-tree` so Vite resolves its ESM build correctly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6859483d80e883218a97c463263ff55f