### PR TITLE
Install OpenSSL in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 
 # install deps
 COPY package*.json prisma ./
+RUN apt-get update -y && apt-get install -y openssl
 RUN npm ci
 
 # copy source and build
@@ -15,6 +16,7 @@ FROM node:20-slim
 WORKDIR /app
 ENV NODE_ENV=production
 COPY --from=build /app /app
+RUN apt-get update -y && apt-get install -y openssl
 RUN npm prune --production
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
## Summary
- install `openssl` in both build and runtime layers

## Testing
- `docker build -t skill_tree_test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_b_68595bee06548321bb85a4697a5bd697