### PR TITLE
Add .dockerignore to reduce Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist-server
+data
+.git
+*.log


### PR DESCRIPTION
## Summary
- ignore development artifacts during Docker builds

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68595bfb977883219464bbe8cb1a2880