### PR TITLE
Fix ES module build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,9 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "dist-server",
-    "module": "commonjs",
-    "target": "es2019",
+    "module": "es2022",
+    "target": "es2022",
+    "moduleResolution": "node",
     "esModuleInterop": true,
     "skipLibCheck": true
   },


### PR DESCRIPTION
## Summary
- compile server TypeScript to ES2022 modules
- use Node module resolution

## Testing
- `npx tsc --noEmit`
- `npm run build-server`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68595e14af448321a61374da0d204417