### PR TITLE
Expose dev server on all interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ npm run server # starts API on :4000
 npm run dev    # starts Vite dev server on :3000
 ```
 
+To reach the frontend from other machines (e.g. when running on a VPS),
+start the dev server with the `--host` flag or set `server.host` in
+`vite.config.ts` so Vite listens on all interfaces:
+
+```bash
+npm run dev -- --host
+```
+
 ## Docker
 
 You can build and run the project using Docker:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
     }
   },
   server: {
-    port: 3000
+    port: 3000,
+    // Listen on all network interfaces so the dev server is reachable
+    // from other machines (e.g. when running on a VPS)
+    host: true
   }
 });


### PR DESCRIPTION
## Summary
- update the quick start docs with instructions on exposing the dev server
- configure Vite to listen on all network interfaces

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68595fcc6a3883219251578242eabd70