### PR TITLE
Add Vite development service to docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ You can build and run the project using Docker:
 docker compose up --build
 ```
 
-The API will be available on port `4000` and data will persist in the `./data` folder.
+The API will be available on port `4000` and the Vite dev server on port `3000`.
+Persisted SQLite data will be stored in the `./data` folder.
 
 ### Runtime requirements
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,16 @@ services:
       DATABASE_URL: "file:/app/data/db.sqlite"
       JWT_SECRET: "change_me"
     restart: unless-stopped
+
+  vite:
+    image: node:20-slim
+    working_dir: /app
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/app
+    command: sh -c "npm install && npm run dev -- --host"
+    environment:
+      NODE_ENV: development
+    depends_on:
+      - skilltree


### PR DESCRIPTION
## Summary
- extend `docker-compose.yml` with a `vite` service
- document new port in README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6859633920b483218d17822273d467c5