### PR TITLE
Enable skill deselection and tooltip

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -101,4 +101,17 @@ app.post('/api/skill/:id/complete', auth, async (req, res) => {
   res.json({ ok: true });
 });
 
+app.delete('/api/skill/:id/complete', auth, async (req, res) => {
+  const userId = (req as any).userId;
+  const skillId = req.params.id;
+  try {
+    await prisma.userSkill.delete({
+      where: { userId_skillId: { userId, skillId } },
+    });
+  } catch (e) {
+    // ignore if record doesn't exist
+  }
+  res.json({ ok: true });
+});
+
 app.listen(4000, () => console.log('Server started on http://localhost:4000'));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,8 +48,12 @@ function App() {
             skills={data.skills}
             completed={data.completedSkillIds}
             highlighted={highlighted}
-            onComplete={async (id) => {
-              await axios.post(`/api/skill/${id}/complete`);
+            onToggle={async (id, isCompleted) => {
+              if (isCompleted) {
+                await axios.delete(`/api/skill/${id}/complete`);
+              } else {
+                await axios.post(`/api/skill/${id}/complete`);
+              }
               refetch();
             }}
           />

--- a/src/components/SkillTreeView.tsx
+++ b/src/components/SkillTreeView.tsx
@@ -14,7 +14,7 @@ interface Props {
   skills: Skill[];
   completed: string[];
   highlighted: string[];
-  onComplete: (id: string) => Promise<void>;
+  onToggle: (id: string, completed: boolean) => Promise<void>;
 }
 
 /** Compute hierarchical levels for skills */
@@ -55,7 +55,7 @@ const buildGraph = (
     levelSkills.forEach((s, idx) => {
       nodes.push({
         id: s.id,
-        data: { label: s.title },
+        data: { label: <div title={s.description}>{s.title}</div> },
         position: { x: lvl * 250, y: idx * 120 },
         style: {
           border: highlighted.includes(s.id)
@@ -76,11 +76,20 @@ const buildGraph = (
   return { nodes, edges };
 };
 
-const SkillTreeView = ({ skills, completed, highlighted, onComplete }: Props) => {
+const SkillTreeView = ({ skills, completed, highlighted, onToggle }: Props) => {
   const { nodes, edges } = useMemo(
     () => buildGraph(skills, completed, highlighted),
     [skills, completed, highlighted]
   );
+
+  const handleClick = (_: any, node: Node) => {
+    const skill = skills.find((s) => s.id === node.id)!;
+    const isCompleted = completed.includes(skill.id);
+    const prereqsMet = skill.prereqIds.every((p) => completed.includes(p));
+
+    if (!isCompleted && !prereqsMet) return;
+    onToggle(skill.id, isCompleted);
+  };
 
   return (
     <div style={{ width: '100%', height: '600px' }}>
@@ -90,7 +99,7 @@ const SkillTreeView = ({ skills, completed, highlighted, onComplete }: Props) =>
         nodesDraggable={false}
         panOnDrag={false}
         zoomOnScroll={false}
-        onNodeClick={(_, node) => onComplete(node.id)}
+        onNodeClick={handleClick}
         fitView
       >
         <Background />


### PR DESCRIPTION
## Summary
- allow toggling completion of a skill via new delete endpoint
- only let users complete a skill if prerequisites were met
- restore hover descriptions using node tooltips

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68597ed898e083218249bda26f6620db