### PR TITLE
Update layout and style

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ function App() {
   return (
     <div className="h-screen flex flex-col">
       <div className="flex flex-1 overflow-hidden">
-        <div className="w-1/4 border-r overflow-y-auto">
+        <div className="w-1/4 border-r overflow-y-auto bg-[#003a7c]">
           <CourseSidebar
             courses={data.courses}
             skills={data.skills}

--- a/src/components/CourseSidebar.tsx
+++ b/src/components/CourseSidebar.tsx
@@ -21,7 +21,7 @@ const CourseSidebar = ({ courses, onHover }: Props) => {
       {courses.map((c) => (
         <li
           key={c.id}
-          className="p-2 border rounded hover:bg-gray-100"
+          className="p-2 border rounded hover:bg-gray-100 bg-[#ffca35]"
           onMouseEnter={() => onHover(c.skillIds)}
           onMouseLeave={() => onHover([])}
         >

--- a/src/components/SkillTreeView.tsx
+++ b/src/components/SkillTreeView.tsx
@@ -57,6 +57,8 @@ const buildGraph = (
         id: s.id,
         data: { label: <div title={s.description}>{s.title}</div> },
         position: { x: lvl * 250, y: idx * 120 },
+        sourcePosition: 'right',
+        targetPosition: 'left',
         style: {
           border: highlighted.includes(s.id)
             ? '2px solid orange'


### PR DESCRIPTION
## Summary
- revert node handle positions to use left and right
- keep yellow course buttons and blue sidebar frame

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68598426d0a4832186eef9053b72c91c